### PR TITLE
Fixes existing directory create

### DIFF
--- a/app/prestart.sh
+++ b/app/prestart.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 echo "Run flask migration upgrades (show current version first)"
-mkdir - db/
+mkdir -p db/
 flask db current
 flask db upgrade
 


### PR DESCRIPTION
Was getting a directory alreay exists error in the logs.
-p allows it to create all directories in a path without erroring if one already exits.