### PR TITLE
Build Docker container in GitHub actions

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,0 +1,51 @@
+name: Build Docker container
+
+env:
+  GITHUB_TAG: ghcr.io/${{ github.repository }}
+
+on:
+  push:
+    branches-ignore:
+      - '*.tmp'
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docker:
+    name: Build Docker container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.GITHUB_TAG }}
+          tags: |
+            "type=ref,event=branch"
+            "type=ref,suffix=-{{sha}},event=branch"
+            "type=ref,suffix=-{{date 'YYYYMMDD'}},event=branch"
+            "type=ref,event=tag"
+            "type=ref,event=pr"
+            "type=raw,value=latest,enable={{is_default_branch}}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
For each branch, build a docker container inside GitHub
actions and push the resultant image to GitHub container
registry.

Builds from the default branch are tagged as latest, while
branches and tags also are pushed to the container registry
to keep the container history tied to the repository
metadata.

Signed-off-by: Christopher Obbard <chris@64studio.com>

an example run is available at: https://github.com/obbardc/groceri.es/runs/7938095796?check_suite_focus=true
an example container is available from: `docker pull ghcr.io/obbardc/groceri.es:wip-obbardc-build-docker-container-ci`